### PR TITLE
fix: handling duplicated files when download spectra

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Fix bug in ftp url encoding.
 - Improve performance `massive_ftp_path()`.
 - Add `massive_number_files()`.
+- Fix bug handling duplicates files.
 - Update examples and tests
 
 ## Changes in 0.1.5

--- a/R/GNPS2_functions.R
+++ b/R/GNPS2_functions.R
@@ -110,6 +110,20 @@ gnps2_query <- function(id = character(), usi_pattern = "*",
                                        project_anno$filepath), ]
     if(!nrow(project_anno))
         stop("No files found with corresponding `filepath` pattern.")
+
+    ## If there are MS duplicated files, keep only the files in "ccms_peak" dir
+    project_anno$filename <- basename(project_anno$filepath)
+    if(any(duplicated(project_anno$filename))) {
+        dup_files <- project_anno[duplicated(project_anno$filename), "filename"]
+        if(any(grepl("^ccms_peak",
+                     project_anno[project_anno$filename %in% dup_files,
+                                  "filepath"]))) {
+            idx <- c(which(!(project_anno$filename %in% dup_files)),
+                     which(grepl("^ccms_peak", project_anno$filepath) &
+                           project_anno$filename %in% dup_files))
+            project_anno <- project_anno[idx, ]
+        }
+    }
     project_anno
 }
 

--- a/R/GNPS2_functions.R
+++ b/R/GNPS2_functions.R
@@ -118,6 +118,8 @@ gnps2_query <- function(id = character(), usi_pattern = "*",
         if(any(grepl("^ccms_peak",
                      project_anno[project_anno$filename %in% dup_files,
                                   "filepath"]))) {
+            warning("Found ", length(dup_files), " duplicated files. Keep ",
+                    "only the duplicated files in 'ccms_peak' folder.")
             idx <- c(which(!(project_anno$filename %in% dup_files)),
                      which(grepl("^ccms_peak", project_anno$filepath) &
                            project_anno$filename %in% dup_files))

--- a/tests/testthat/test_GNPS2_functions.R
+++ b/tests/testthat/test_GNPS2_functions.R
@@ -46,6 +46,10 @@ test_that("gnps2_query works", {
     res <- gnps2_query("MSV000100512", filepath_pattern = "metadata")
     expect_true(is.data.frame(res))
     expect_true(nrow(res) == 2)
+
+    expect_warning(gnps2_query("MSV000093072"), "duplicated files")
+    res <- gnps2_query("MSV000093072")
+    expect_true(nrow(res) == 97)
 })
 
 test_that("gnps2_usi_download_link works", {

--- a/tests/testthat/test_MassIVE_functions.R
+++ b/tests/testthat/test_MassIVE_functions.R
@@ -89,6 +89,8 @@ test_that("massive_ftp_path works", {
 test_that("massive_list_files works", {
     expect_error(massive_list_files(c("MSV000083058", "MSV000080547")),
                  "Provide a single MassIVE ID")
+    res <- massive_list_files("MSV000093072")
+    expect_true(length(res) == 97)
 })
 
 test_that("massive_delete_cache works", {


### PR DESCRIPTION
Handling the duplicated spectra files and downloading only the ones in the `"ccms_peak"` folder